### PR TITLE
Fixed problem with removeAllResources

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ function extendUploadOpts(newUploadOpts) {
 
 function removeAllResources(uploadOpts) {
 
+    var that = this;
+
     // if we get upload opts here, clone existing and override
     uploadOpts = uploadOpts ?
         extend(clone(that.uploadOpts), uploadOpts) :


### PR DESCRIPTION
Added missing declaration in `removeAllResources()` function.

This PR issue https://github.com/K15t/gulp-viewport/issues/2
