### PR TITLE
Example gulpfile does not work with built-in themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,12 @@ To set up gulp-watch and BrowserSync:
     
 ### Example gulpfile.js
 
-Checkout ``example/gulpfile.js`` for a full example gulpfiles.
+Checkout ``example/gulpfile.js`` for a full example gulpfile. This example assumes theme source is found in a
+src/ subdirectory. To start from an existing theme, download the theme jar and unpack into src/, e.g.:
 
+cd example
+mkdir src/
+unzip -d src/ /tmp/scroll-webhelp-theme-2.4.3.jar
 
 ## Known Limitations
 

--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -29,7 +29,7 @@ var VIEWPORT_URL = 'http://localhost:1990/confluence/path-prefix';
 
 
 var viewportTheme = new ViewportTheme(THEME_NAME, TARGET, {
-    sourceBase: 'assets'
+    sourceBase: 'src'
 });
 
 
@@ -45,37 +45,37 @@ gulp.task('watch', function () {
         success: browserSync.reload
     });
 
-    gulp.watch('assets/fonts/**/*', ['fonts']);
-    gulp.watch('assets/img/**/*', ['img']);
-    gulp.watch('assets/js/**/*', ['js']);
-    gulp.watch('assets/less/**.less', ['less']);
-    gulp.watch('assets/**/*.vm', ['templates']);
+    gulp.watch('src/assets/fonts/**/*', ['fonts']);
+    gulp.watch('src/assets/img/**/*', ['img']);
+    gulp.watch('src/assets/js/**/*', ['js']);
+    gulp.watch('src/assets/less/**.less', ['less']);
+    gulp.watch('src/**/*.vm', ['templates']);
 });
 
 
 gulp.task('fonts', function () {
-    return gulp.src('assets/fonts/**/*.*')
+    return gulp.src('src/assets/fonts/**/*.*')
         .pipe(viewportTheme.upload())
         .pipe(gulp.dest('build/fonts'));
 });
 
 
 gulp.task('img', function () {
-    return gulp.src('assets/img/**/*')
+    return gulp.src('src/assets/img/**/*')
         .pipe(viewportTheme.upload())
         .pipe(gulp.dest('build/img'));
 });
 
 
 gulp.task('js', function () {
-    return gulp.src('assets/js/**/*.*')
+    return gulp.src('src/assets/js/**/*.*')
         .pipe(viewportTheme.upload())
         .pipe(gulp.dest('build/js'));
 });
 
 
 gulp.task('less', function () {
-    return gulp.src('assets/less/main.less')
+    return gulp.src('src/assets/less/main.less')
         .pipe(gulpSourcemaps.init())
         .pipe(gulpLess())
         .pipe(minifyCss())
@@ -86,14 +86,14 @@ gulp.task('less', function () {
 });
 
 gulp.task('css', function () {
-    return gulp.src('assets/css/**/*.css')
+    return gulp.src('src/assets/css/**/*.css')
         .pipe(viewportTheme.upload())
         .pipe(gulp.dest('build/css'));
 });
 
 
 gulp.task('templates', function () {
-    return gulp.src('assets/**/*.vm')
+    return gulp.src('src/**/*.vm')
         .pipe(viewportTheme.upload())
         .pipe(gulp.dest('build'));
 });

--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -85,6 +85,12 @@ gulp.task('less', function () {
         .pipe(gulp.dest('build/css'));
 });
 
+gulp.task('css', function () {
+    return gulp.src('assets/css/**/*.css')
+        .pipe(viewportTheme.upload())
+        .pipe(gulp.dest('build/css'));
+});
+
 
 gulp.task('templates', function () {
     return gulp.src('assets/**/*.vm')

--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -48,6 +48,7 @@ gulp.task('watch', function () {
     gulp.watch('src/assets/fonts/**/*', ['fonts']);
     gulp.watch('src/assets/img/**/*', ['img']);
     gulp.watch('src/assets/js/**/*', ['js']);
+    gulp.watch('src/assets/css/**.css', ['css']);
     gulp.watch('src/assets/less/**.less', ['less']);
     gulp.watch('src/**/*.vm', ['templates']);
 });


### PR DESCRIPTION
Hi,

This pull request fixes example/gulpfile.js to assume all theme source is present in a src/ subdirectory. New users can get started downloading a theme jar, unzipping its contents into src/ and running 'gulp upload'.

The existing gulpfile.js is confused as to where theme source lives. It has `sourceBase: 'assets'`, but .vm files don't belong in `assets/`, and specifying `sourceBase: 'assets'` also prevents the creation of an `assets/` subdirectory inside the theme, like in the built-in themes.

I've also added a 'css' target for copying across `src/assets/css` contents.
