### PR TITLE
Update config scheme, upload to use multipart and hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ gulp.task('templates', function () {
 });
 ```
 
+`viewportTheme.upload()` accepts options that can override the initial ones. This is useful for setting `sourceBase` and `targetPath` on demand.
+
 ### Upload preprocessed files
 
 Especially CSS and JS files usually need some batching, minification and other pre-processing.

--- a/README.md
+++ b/README.md
@@ -1,110 +1,173 @@
 # gulp-viewport
 
+[![](https://img.shields.io/npm/v/gulp-viewport.svg)](https://www.npmjs.com/package/gulp-viewport) [![](https://img.shields.io/npm/dt/gulp-viewport.svg)](https://www.npmjs.com/package/gulp-viewport) [![](https://img.shields.io/twitter/follow/k15tsoftware.svg?style=social&label=Follow)](https://twitter.com/k15tsoftware)
+
+<!-- toc orderedList:0 depthFrom:2 depthTo:6 -->
+
+* [Get started](#get-started)
+    * [Upload all files in a pipeline](#upload-all-files-in-a-pipeline)
+    * [Upload preprocessed files](#upload-preprocessed-files)
+    * [Set-up BrowserSync](#set-up-browsersync)
+    * [Delete all files from theme](#delete-all-files-from-theme)
+    * [Example gulpfile.js](#example-gulpfilejs)
+* [Using gulp without a .viewportrc for CI server](#using-gulp-without-a-viewportrc-for-ci-server)
+* [Known Limitations](#known-limitations)
+* [Resources & Further Reading](#resources-further-reading)
+* [Licensing](#licensing)
+
+<!-- tocstop -->
+
 The Gulp plugin for Scroll Viewport uploads theme resources directly into Scroll Viewport.
 
-This is useful, when developing a Scroll Viewport theme in a local IDE. In this case, a Gulp
-file can watch the resources, automatically upload the resources to Scroll Viewport, and
-even have for example BrowserSync to sync the browser.
+This is useful, when developing a Scroll Viewport theme in a local IDE. In this case, a Gulp file can watch the resources, automatically upload the resources to Scroll Viewport, and even have for example BrowserSync to sync the browser.
+
+Looking for the old version documentation? [See readme for 1.2.0](https://github.com/K15t/gulp-viewport/blob/ba1c5bb0ff4d3b938ecca37e017c21bb833867a3/README.md).
 
 ## Get started
 
-Create a config file ``~/.viewportrc`` that contains a list of all systems to which you want
-to upload theme.
+Create a config file `~/.viewportrc` that contains a list of all systems to which you want to upload theme.
 
-    [DEV]
-    confluenceBaseUrl=http://localhost:1990/confluence
-    username=admin
-    password=admin
+```yaml
+[DEV]
+confluenceBaseUrl=http://localhost:1990/confluence
+username=admin
+password=admin
+```
 
-Each section in the file is represents a Confluence server, also called "target system". 
-In the example above there is one target system called "DEV".                                                                    
+Each section in the file is represents a Confluence server, also called **target system**.
+In the example above there is one target system called **DEV**.
 
 Then you can use the Gulp Viewport plugin in your gulp file like the following:
 
-    var viewportTheme = new ViewportTheme('the-theme-name', 'DEV');
+```js
+var ViewportTheme = require('gulp-viewport');
 
-### Using process.env
+var viewportTheme = new ViewportTheme({
+    themeName: 'your-theme',
+    // target system
+    env: 'DEV'
+});
+```
 
-If you do not want to rely on a `.viewportrc` sitting in your home, or need automated builds on a CI server, you can use the following `process.env` variables:
+Below is the full list of configuration options:
 
-* USER: Username
-* PASS: Password
-* URL: The Confluence base URL
+```js
+var viewportTheme = new ViewportTheme({
+    // name of the theme to upload to
+    themeName: 'your-theme-name',
+    // For home-config users of .viewportrc - defines which config to use for target
+    env: 'DEV',
+    // If you want to set up your target via the gulpfile instead of a .viewportrc, use this.
+    // Notice that you should NOT check in your credentials with git!
+    // omit env, if you are using target.
+    target: {
+        // https://your-installation.com/confluence/
+        confluenceBaseUrl: ,
+        // A user that is eligible to update viewport themes in the given space
+        username: ,
+        password: ,
+    },
+    // If the source is placed in a subfolder (dist/theme/...) use this path
+    sourceBase: ,
+    // If the source has to be placed somewhere else than /
+    targetPath: ,
+});
+```
 
+### Upload all files in a pipeline
 
-    USER=youruser PASS=yourpass URL=https://your-confluence-installation.com gulp upload
+The gulp-viewport plugin provides a special destination, that uploads a files in the pipeline to a target (that has been defined in the `~/.viewportrc` file).
 
+```js
+gulp.task('templates', function () {
+    return gulp.src('assets/**/*.vm')
+        .pipe(viewportTheme.upload());    // upload to viewport theme
+});
+```
 
-### Upload all files in pipeline
-
-The gulp-viewport plugin provides a special destination, that uploads a files in the
-pipeline to a target (that has been defined in the ``~/.viewportrc`` file).
-
-    gulp.task('templates', function () {
-        return gulp.src('assets/**/*.vm')
-            .pipe(viewportTheme.upload());    // upload to viewport theme
-    }
-
-
-### Upload preprocessed file(s)
+### Upload preprocessed files
 
 Especially CSS and JS files usually need some batching, minification and other pre-processing.
 Here is how to do it.
 
-    gulp.task('less', function () {
-        return gulp.src('assets/less/main.less')
-            .pipe(gulpSourcemaps.init())
-            .pipe(gulpLess())
-            .pipe(minifyCss())
-            .pipe(viewportTheme.upload({
-                targetPath: 'css/main.css'    // target destination of batched file    
-            }));
-    });
-
+```js
+gulp.task('less', function () {
+    return gulp.src('assets/less/main.less')
+        .pipe(gulpSourcemaps.init())
+        .pipe(gulpLess())
+        .pipe(minifyCss())
+        .pipe(viewportTheme.upload({
+            targetPath: 'css/main.css'    // target destination of batched file
+        }));
+});
+```
 
 ### Set-up BrowserSync
 
 For development gulp-watch and BrowserSync is super handy.
 
 To set up gulp-watch and BrowserSync:
+```js
+// Dependencies
+var browserSync = require('browser-sync').create();
+// [...]
+var ViewportTheme = require('gulp-viewport');
 
-    // Dependencies
-    var browserSync = require('browser-sync').create();
-    [...]
-    var ViewportTheme = require('gulp-viewport');
 
+var viewportTheme = new ViewportTheme({
+    themeName: 'theme-name',
     // The target system needs to match with a section in .viewportrc
-    var TARGET = 'DEV';
+    env: 'DEV',
+    sourceBase: 'assets'
+});
 
-    var viewportTheme = new ViewportTheme('the-theme-name', TARGET, { sourceBase: 'assets' });
+gulp.task('watch', function () {
 
-    gulp.task('watch', function () {
-
-        // init browser sync.
-        browserSync.init({
-            open: false,
-            proxy: 'http://localhost:1990/confluence/vsn',   // the target needs to define a viewportUrl
-        });
-
-        // Override the UPLOAD_OPTS to enable auto reload.
-        viewportTheme.extendUploadOpts({
-            success: browserSync.reload
-        });
-
-        gulp.watch('assets/less/**.less', ['less']);
-        gulp.watch('assets/**/*.vm', ['templates']);
-        // ... create more watches for other file types here
+    // init browser sync.
+    browserSync.init({
+        open: false,
+        // the target needs to define a viewportUrl
+        proxy: 'http://localhost:1990/confluence',
     });
 
+    // Override the UPLOAD_OPTS to enable auto reload.
+    viewportTheme.on('uploaded', browserSync.reload);
+
+    gulp.watch('assets/less/**.less', ['less']);
+    gulp.watch('assets/**/*.vm', ['templates']);
+    // ... create more watches for other file types here
+});
+```
 
 ### Delete all files from theme
-
-    gulp.task('reset-theme', function () {
-        viewportTheme.removeAllResources();
-    });
-
+```js
+gulp.task('reset-theme', function () {
+    viewportTheme.removeAllResources();
+});
+```
 
 ### Example gulpfile.js
+
+Checkout [example/gulpfile.js](example/gulpfile.js) for a full example gulpfiles.
+
+## Using gulp without a .viewportrc for CI server
+
+For tools like Bitbucket pipelines, where you can't rely on a file `.viewportrc` sitting in your home, or need automated builds on a CI server, you can use the following `process.env` variables:
+
+* VPRT_THEMENAME - `themeName`
+* VPRT_THEMEID - `themeId`
+* VPRT_ENV - `env`
+* VPRT_CONFLUENCEBASEURL - `target.confluenceBaseUrl`
+* VPRT_USERNAME - `target.username`
+* VPRT_PASSWORD - `target.password`
+* VPRT_SOURCEBASE - `sourceBase`
+* VPRT_TARGETPATH - `targetPath`
+
+Same with the config for the gulpfile: you can omit `env` if you use `user`, `password` and `url`.
+
+```
+VPRT_THEMENAME=my-theme VPRT_USERNAME=user VPRT_PASSWORD=secret VPRT_CONFLUENCEBASEURL=https://your-confluence-installation.com gulp upload
+```
 
 Checkout ``example/gulpfile.js`` for a full example gulpfile. This example assumes theme source is found in a
 src/ subdirectory. To start from an existing theme, download the theme jar and unpack into src/, e.g.:
@@ -115,12 +178,8 @@ unzip -d src/ /tmp/scroll-webhelp-theme-2.4.3.jar
 
 ## Known Limitations
 
-* Please make sure to upgrade to Scroll Viewport 2.3.1, the Gulp plugin will
-  not work with any version before that.  
-* When using the ``gulp-watch`` file that are deleted or move locally, will
-  not automatically be deleted or moved in Confluence. In order to reset a theme
-  use ``viewportTheme.removeAllResources()`` to remove all files and then
-  upload all files from scratch.
+* Please make sure to upgrade to Scroll Viewport 2.7.1, the Gulp plugin will not work with any version before that. If you look to support an older version, make sure to install 1.2.0 of the plugin ([See readme 1.2.0]((https://github.com/K15t/gulp-viewport/blob/ba1c5bb0ff4d3b938ecca37e017c21bb833867a3/README.md))).
+* When using the `gulp-watch` files that are deleted or moved locally, will not automatically be deleted or moved in Confluence. In order to reset a theme use `viewportTheme.removeAllResources()` to remove all files and then upload all files from scratch.
 
 
 ## Resources & Further Reading

--- a/example/gulpfile.js
+++ b/example/gulpfile.js
@@ -28,7 +28,9 @@ var THEME_NAME = 'k15t-doc-theme';
 var VIEWPORT_URL = 'http://localhost:1990/confluence/path-prefix';
 
 
-var viewportTheme = new ViewportTheme(THEME_NAME, TARGET, {
+var viewportTheme = new ViewportTheme({
+    env: TARGET,
+    themeName: THEME_NAME,
     sourceBase: 'src'
 });
 
@@ -41,9 +43,7 @@ gulp.task('watch', function () {
         proxy: VIEWPORT_URL
     });
 
-    viewportTheme.extendUploadOpts({
-        success: browserSync.reload
-    });
+    viewportTheme.on('uploaded', browserSync.reload);
 
     gulp.watch('src/assets/fonts/**/*', ['fonts']);
     gulp.watch('src/assets/img/**/*', ['img']);

--- a/index.js
+++ b/index.js
@@ -1,213 +1,176 @@
-"use strict";
+"use strict"
+var fs = require('fs')
+var gutil = require('gulp-util')
+var homeConfig = require('home-config')
+var path = require('path')
+var request = require('request')
+var syncRequest = require('sync-request')
+var strformat = require('strformat')
+var through = require("through2")
+var observable = require("riot-observable")
 
-var clone = require('clone');
-var extend = require('extend');
-var fs = require('fs');
-var gutil = require('gulp-util');
-var homeConfig = require('home-config');
-var path = require('path');
-var request = require('request');
-var syncRequest = require('sync-request');
-var strformat = require('strformat');
-var through = require("through2");
+const PLUGIN_NAME = 'gulp-viewport'
+const VIEWPORTRC = homeConfig.load('.viewportrc')
 
+const THEME_BY_NAME_REST_URL = '/rest/scroll-viewport/1.0/theme?name={0}'
+const UPDATE_REST_URL = '/rest/scroll-viewport/1.0/theme/{0}/resource'
+const DELETE_REST_URL = '/rest/scroll-viewport/1.0/theme/{0}/resource'
 
-const PLUGIN_NAME = 'gulp-viewport-uploader';
-const VIEWPORTRC = homeConfig.load('.viewportrc');
-
-const THEME_BY_NAME_REST_URL = '/rest/scroll-viewport/1.0/theme?name={0}';
-const UPDATE_REST_URL = '/rest/scroll-viewport/1.0/theme/{0}/resource';
-const DELETE_REST_URL = '/rest/scroll-viewport/1.0/theme/{0}/resource';
-
-const LOG_ENABLED = true;
-const DEBUG_ENABLED = true;
+module.exports = class ViewportTheme {
+    constructor(options) {
 
 
-var ViewportTheme = function (themeName, targetSystemKey, uploadOpts) {
-    this.targetSystem = getTargetConfig(targetSystemKey);
-    this.themeId = getThemeId(this.targetSystem, themeName);
-    this.uploadOpts = uploadOpts;
+        // allow events to be triggered and listened to
+        observable(this)
 
-    log();
-    log('======================================================');
-    log('   You are deploying \'' + themeName + '\'to:');
-    log('   ' + this.targetSystem.confluenceBaseUrl);
-    log('======================================================');
-    log();
+        // Options are set via ENV variables, GULP Config and/or .viewportrc config
+        const defaultOptions = {
+            // If not existing, determine key using the id. one of the two has to exist
+            themeName: process.env.VPRT_THEMENAME,
+            // It is usually easier to use the themeName, but if needed - the id can be used.
+            themeId: process.env.VPRT_THEMEID,
+            // For home-config users of .viewportrc - defines which config to use for target
+            env: process.env.VPRT_ENV,
+            // If you do not want to use a .viewportrc file, you can manually pass the target opts
+            target: {
+                // https://your-installation.com/confluence/
+                confluenceBaseUrl: process.env.VPRT_CONFLUENCEBASEURL,
+                // A user that is eligible to update viewport themes in the given space
+                username: process.env.VPRT_USERNAME,
+                password: process.env.VPRT_PASSWORD,
+            },
+            // If the source is placed in a subfolder (dist/theme/...) use this path
+            sourceBase: process.env.VPRT_SOURCEBASE,
+            // If the source has to be placed somewhere else than /
+            targetPath: process.env.VPRT_TARGETPATH,
+        }
 
-    function getTargetConfig(targetSystemKey) {
-        if (process.env.hasOwnProperty('USER')
-            && process.env.hasOwnProperty('PASS')
-            && process.env.hasOwnProperty('URL')) {
-            var config = {
-                confluenceBaseUrl : process.env.URL,
-                username : process.env.USER,
-                password : process.env.PASS
-            };
-            return config;
-        } else if (!VIEWPORTRC.hasOwnProperty(targetSystemKey)) {
-            throw new gutil.PluginError(PLUGIN_NAME, 'No configuration for target \'' + targetSystemKey + '\' found - check ~/.viewportrc.');
-        } else {
-            return VIEWPORTRC[targetSystemKey];
+        options = Object.assign({}, defaultOptions, options)
+        options.target = Object.assign({}, defaultOptions.target, options.target)
+
+        this.options = this.validateOptions(options)
+
+        this.log(`${this.getUserAnnotation()} Changing theme ${gutil.colors.bold.red(this.options.themeName)} at ${gutil.colors.bold.green(this.options.target.confluenceBaseUrl)}`)
+
+        this.files = []
+    }
+
+    getUserAnnotation() {
+        if (this.options.env) {
+            return `[${gutil.colors.red.bold(this.options.target.username)}@${this.options.env}]`
+        } else if (this.options.target.confluenceBaseUrl) {
+            return `[${gutil.colors.red.bold(this.options.target.username)}]`
         }
     }
 
-    function getThemeId(targetSystem, themeName) {
-        var response = syncRequest('GET', strformat(targetSystem.confluenceBaseUrl + THEME_BY_NAME_REST_URL, themeName),
+    validateOptions(options) {
+        if (options.env && VIEWPORTRC.hasOwnProperty(options.env)) {
+            options.target = Object.assign({}, options.target, VIEWPORTRC[options.env])
+        }
+        if (!options.themeId) {
+            if (!options.themeName) {
+                throw new gutil.PluginError(PLUGIN_NAME, 'themeName or themeId missing')
+            } else {
+                options.themeId = this.getThemeId(options)
+            }
+        }
+        if (!options.targetPath) {
+            options.targetPath = './'
+        }
+        if (!options.sourceBase) {
+            options.sourceBase = './'
+        }
+        return options
+    }
+
+    getThemeId(options) {
+        var response = syncRequest('GET', strformat(options.target.confluenceBaseUrl + THEME_BY_NAME_REST_URL, options.themeName),
             {
                 headers: {
-                    'Authorization': ('Basic ' + new Buffer(targetSystem.username + ':' + targetSystem.password).toString('base64'))
+                    'Authorization': ('Basic ' + new Buffer(options.target.username + ':' + options.target.password).toString('base64'))
                 }
-            });
+            })
 
         if (response.statusCode != 200) {
-            throw new gutil.PluginError(PLUGIN_NAME, 'Theme \'' + themeName + '\' not found on \'' + targetSystem.confluenceBaseUrl +
-                '\'! Create a new theme named exactly like this to fix.');
+            throw new gutil.PluginError(PLUGIN_NAME, 'Theme \'' + options.themeName + '\' not found on \'' + options.target.confluenceBaseUrl +
+                '\'! Create a new theme named exactly like this to fix.')
         }
 
-        return JSON.parse(response.getBody('utf8')).id;
-    }
-};
-
-
-function upload(uploadOpts) {
-
-    var that = this;
-
-    // if we get upload opts here, clone existing and override
-    uploadOpts = uploadOpts ?
-        extend(clone(that.uploadOpts), uploadOpts) :
-        that.uploadOpts;
-
-    if (!this.themeId) {
-        throw new gutil.PluginError(PLUGIN_NAME, 'Missing options.themeId!');
+        return JSON.parse(response.getBody('utf8')).id
     }
 
-    if (!uploadOpts.sourceBase && !uploadOpts.targetPath) {
-        throw new gutil.PluginError(PLUGIN_NAME, 'Missing uploadOpts.sourceBase or uploadOpts.targetPath!');
+    log(message) {
+        // if we use the default console.log, objects and arrays are displayed nicely (though, wihout [plugin-name] branding)
+        // we have this function, so we can still change it to our liking
+        console.log(message)
     }
 
-    // Creating a stream through which each file will pass
-    return through.obj(function (file, enc, cb) {
-
-        if (file.isNull()) {
-            // return empty file
-            return cb(null, file);
-        }
-
-        uploadFile(file, that, uploadOpts, cb);
-
-        // cb(null, file);
-    });
-
-}
-
-
-function uploadFile(file, viewportTheme, uploadOpts, cb) {
-    if (!uploadOpts.targetPath) {
-        var targetPath = path.relative(path.join(file.cwd, uploadOpts.sourceBase), file.history[file.history.length - 1]);
-        targetPath = path.normalize(targetPath);
-    } else {
-        targetPath = uploadOpts.targetPath;
+    error(message) {
+        // if we use the default console.log, objects and arrays are displayed nicely (though, wihout [plugin-name] branding)
+        // we have this function, so we can still change it to our liking
+        console.error(message)
     }
 
-    debug('Uploading \'' + file.history[0] + '\' to \'' + targetPath + '\'.');
+    upload() {
+        this.trigger('upload')
+        return through.obj(
+            (file, enc, cb) => {
+                // If file exists, add it to our queue
+                if (!file.isNull()) {
+                    let relativePath = path.relative(this.options.targetPath, file.history[0])
+                    this.files.push(
+                        {
+                            path: path.relative(this.options.sourceBase, file.history[0]),
+                            file: fs.createReadStream(relativePath)
+                        }
+                    )
+                }
+                cb(null, file)
+            },
+            (cb) => {
+                let files = this.files.map(item=>item.file)
+                let locations = this.files.map(item=>item.path)
+                request({
+                    url: strformat(this.options.target.confluenceBaseUrl + UPDATE_REST_URL, this.options.themeId),
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'multipart/form-data',
+                        'Authorization': ('Basic ' + new Buffer(this.options.target.username + ':' + this.options.target.password).toString('base64'))
+                    },
+                    formData: { files, locations }
+                }, (error, response) => {
+                    if (response.statusCode === 201) {
+                        let uploadedFiles = JSON.parse(response.body)
+                        uploadedFiles.map(item=>this.log(item))
+                        this.log(`${uploadedFiles.length} Files ${gutil.colors.bold.green('successfully')} uploaded.`)
+                        this.trigger('uploaded')
+                    } else {
+                        this.error('Error while uploading files: ' + response.statusCode + ' - ' + response.statusMessage)
+                        this.trigger('error')
+                    }
+                    cb(null)
+                })
+            }
+        )
+    }
 
-    file.pipe(request({
-        url: strformat(viewportTheme.targetSystem.confluenceBaseUrl + UPDATE_REST_URL, viewportTheme.themeId),
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/octet-stream',
-            'Content-Length': file.contents.length,
-            'X-Scroll-Viewport-Resource-Location': targetPath,
-            'Authorization': ('Basic ' + new Buffer(viewportTheme.targetSystem.username + ':' + viewportTheme.targetSystem.password).toString('base64'))
-        }
-
-    }, function (error, response) {
-        if (response.statusCode === 201) {
-            uploadOpts.success && uploadOpts.success(file, response);
-            log('File \'' + JSON.parse(response.body).name + '\' successfully uploaded.');
-
-        } else {
-            uploadOpts.error && uploadOpts.error(file, response);
-            log('Error while uploading file to \'' + targetSystem.confluenceBaseUrl + '\':\n' +
-                response.statusCode + ' - ' + response.statusMessage);
-        }
-        cb(null, file)
-    }));
-
-}
-
-
-function extendUploadOpts(newUploadOpts) {
-    extend(this.uploadOpts, newUploadOpts);
-}
-
-
-function removeAllResources(uploadOpts) {
-
-    var that = this;
-
-    // if we get upload opts here, clone existing and override
-    uploadOpts = uploadOpts ?
-        extend(clone(that.uploadOpts), uploadOpts) :
-        that.uploadOpts;
-
-    request({
-        url: strformat(this.targetSystem.confluenceBaseUrl + DELETE_REST_URL, this.themeId),
-        method: 'DELETE',
-        headers: {
-            'Authorization': ('Basic ' + new Buffer(this.targetSystem.username + ':' + this.targetSystem.password).toString('base64'))
-        }
-    }, function (error, response, body) {
-        if (!error && response.statusCode == 204) {
-            log('Resources succesfully removed.');
-        } else {
-            uploadOpts.error && uploadOpts.error(file, response);
-            log('Error while removing resources:\n' +
-                response.statusCode + ' - ' + response.statusMessage);
-        }
-    });
-}
-
-
-function log(msg, obj) {
-    if (LOG_ENABLED) {
-        if (msg) {
-            console.log(msg + objAsString(obj));
-        } else {
-            console.log();
-        }
+    removeAllResources() {
+        this.trigger('remove')
+        request({
+            url: strformat(this.options.target.confluenceBaseUrl + DELETE_REST_URL, this.options.themeId),
+            method: 'DELETE',
+            headers: {
+                'Authorization': ('Basic ' + new Buffer(this.options.target.username + ':' + this.options.target.password).toString('base64'))
+            }
+        }, (error, response, body) => {
+            if (!error && response.statusCode == 204) {
+                this.log('Resources succesfully removed.')
+                this.trigger('removed')
+            } else {
+                this.log('Error while removing resources:\n' +
+                response.statusCode + ' - ' + response.statusMessage)
+                this.trigger('error')
+            }
+        })
     }
 }
-
-
-function objAsString(obj) {
-    var dontLogContents = function (key, value) {
-        if (key == '_contents') {
-            return undefined;
-        } else {
-            return value;
-        }
-    };
-
-    if (obj) {
-        return ' ((' + JSON.stringify(obj, dontLogContents, 4) + '))';
-    } else {
-        return '';
-    }
-}
-
-
-function debug(msg, obj) {
-    if (DEBUG_ENABLED) {
-        console.log(msg + objAsString(obj));
-    }
-}
-
-
-ViewportTheme.prototype.upload = upload;
-ViewportTheme.prototype.extendUploadOpts = extendUploadOpts;
-ViewportTheme.prototype.removeAllResources = removeAllResources;
-
-module.exports = ViewportTheme;

--- a/index.js
+++ b/index.js
@@ -45,10 +45,8 @@ module.exports = class ViewportTheme {
             targetPath: process.env.VPRT_TARGETPATH,
         }
 
-        options = Object.assign({}, defaultOptions, options)
-        options.target = Object.assign({}, defaultOptions.target, options.target)
-
-        this.options = this.validateOptions(options)
+        this.options = defaultOptions
+        this.extendOptions(options)
 
         this.log(`${this.getUserAnnotation()} Changing theme ${gutil.colors.bold.red(this.options.themeName)} at ${gutil.colors.bold.green(this.options.target.confluenceBaseUrl)}`)
 
@@ -60,6 +58,14 @@ module.exports = class ViewportTheme {
             return `[${gutil.colors.red.bold(this.options.target.username)}@${this.options.env}]`
         } else if (this.options.target.confluenceBaseUrl) {
             return `[${gutil.colors.red.bold(this.options.target.username)}]`
+        }
+    }
+
+    extendOptions(options) {
+        if (options) {
+            Object.assign(this.options, options)
+            Object.assign(this.options.target, options.target)
+            this.options = this.validateOptions(this.options)
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,8 @@ module.exports = class ViewportTheme {
         console.error(message)
     }
 
-    upload() {
+    upload(options) {
+        this.extendOptions(options)
         this.trigger('upload')
         return through.obj(
             (file, enc, cb) => {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 "use strict"
+
 var fs = require('fs')
 var gutil = require('gulp-util')
 var homeConfig = require('home-config')
@@ -18,7 +19,6 @@ const DELETE_REST_URL = '/rest/scroll-viewport/1.0/theme/{0}/resource'
 
 module.exports = class ViewportTheme {
     constructor(options) {
-
 
         // allow events to be triggered and listened to
         observable(this)

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = class ViewportTheme {
             if (!options.themeName) {
                 throw new gutil.PluginError(PLUGIN_NAME, 'themeName or themeId missing')
             } else {
-                options.themeId = this.getThemeId(options)
+                options.themeId = this.getThemeId(options.themeName)
             }
         }
         if (!options.targetPath) {
@@ -89,16 +89,17 @@ module.exports = class ViewportTheme {
         return options
     }
 
-    getThemeId(options) {
-        var response = syncRequest('GET', strformat(options.target.confluenceBaseUrl + THEME_BY_NAME_REST_URL, options.themeName),
+    getThemeId(themeName) {
+        var response = syncRequest('GET', strformat(this.options.target.confluenceBaseUrl + THEME_BY_NAME_REST_URL, themeName),
             {
                 headers: {
-                    'Authorization': ('Basic ' + new Buffer(options.target.username + ':' + options.target.password).toString('base64'))
+                    'Authorization': ('Basic ' + new Buffer(this.options.target.username + ':' + this.options.target.password).toString('base64'))
                 }
-            })
+            }
+        )
 
         if (response.statusCode != 200) {
-            throw new gutil.PluginError(PLUGIN_NAME, 'Theme \'' + options.themeName + '\' not found on \'' + options.target.confluenceBaseUrl +
+            throw new gutil.PluginError(PLUGIN_NAME, 'Theme \'' + themeName + '\' not found on \'' + this.options.target.confluenceBaseUrl +
                 '\'! Create a new theme named exactly like this to fix.')
         }
 

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.2.1",
   "description": "The Gulp plugin for Scroll Viewport uploads theme resources directly into Scroll Viewport.",
   "dependencies": {
-    "clone": "^1.0.2",
     "extend": "^3.0.0",
-    "home-config": "^0.1.0",
     "gulp-util": "^3.0.6",
+    "home-config": "^0.1.0",
     "request": "^2.60.0",
+    "riot-observable": "^3.0.0",
     "strformat": "0.0.7",
     "sync-request": "^3.0.0",
     "through2": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "gulp-viewport",
+<<<<<<< HEAD
   "version": "1.2.1",
+=======
+  "version": "2.0.0",
+>>>>>>> 2.0.0
   "description": "The Gulp plugin for Scroll Viewport uploads theme resources directly into Scroll Viewport.",
   "dependencies": {
     "extend": "^3.0.0",


### PR DESCRIPTION
This is a new major version of the plugin.

**Breaking changes**

* Initializing the plugin is now done using one object that contains all the information.
* hooking into success of upload is no longer done by extending the options with an object. Users can use the eventemitter: `viewportTheme.on('uploaded', function(){})`
    * `upload` - before uploading the files
    * `uploaded` - after successful upload
    * `remove` - before removing the files
    * `removed` - after successful remove
    * `error` - when removing or uploading resources failed

**Improvements**
* We use `multipart/form-data` to upload multiple files at once (which requires Viewport 2.7.1 - I added links to the old documentation for use with 2.3.1)
* the config is now validated for missing properties (env/themeName) and throws appropriate error messages.
