### PR TITLE
Add protection against XSRF attacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 [![](https://img.shields.io/npm/dt/gulp-viewport.svg)](https://www.npmjs.com/package/gulp-viewport) 
 [![](https://img.shields.io/twitter/follow/k15tsoftware.svg?style=social&label=Follow)](https://twitter.com/k15tsoftware)
 
+## Deprecation Notice
+The gulp-viewport plugin will be deprecated for its new alternative [viewport-uploader](https://github.com/K15t/viewport-uploader). 
+The new plugin uses webpack for bundling which allows to use ES6 style javascript in your custom theme. gulp-viewport won't receive any 
+more updates in the future.
+
+
+***
+
 <!-- toc orderedList:0 depthFrom:2 depthTo:6 -->
 
 * [Quick Start](#quick-start)

--- a/index.js
+++ b/index.js
@@ -69,12 +69,10 @@ module.exports = class ViewportTheme {
         let newOptions = {target:{}};
         if (options) {
             Object.assign(newOptions, this.options, options);
-            if (options.target) {
-                Object.assign(newOptions.target, this.options.target, options.target);
-            } else {
-                throw new gutil.PluginError(PLUGIN_NAME, 'Cannot find environment \'' + options.env + '\' in \' ~/.viewportrc.');
-            }
+
             return this.validateOptions(newOptions);
+        } else {
+            throw new gutil.PluginError(PLUGIN_NAME, 'Cannot find environment \'' + options.env + '\' in \' ~/.viewportrc.');
         }
     }
 
@@ -244,7 +242,8 @@ module.exports = class ViewportTheme {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'multipart/form-data',
-                        'Authorization': ('Basic ' + new Buffer(options.target.username + ':' + options.target.password).toString('base64'))
+                        'Authorization': ('Basic ' + new Buffer(options.target.username + ':' + options.target.password).toString('base64')),
+                        'X-Atlassian-Token': 'no-check'
                     },
                     formData: { files, locations }
                 }, (error, response) => {

--- a/index.js
+++ b/index.js
@@ -66,20 +66,22 @@ module.exports = class ViewportTheme {
     }
 
     extendOptions(options = {}) {
-        let newOptions = {target:{}};
-        if (options) {
-            Object.assign(newOptions, this.options, options);
+        const newOptions = {
+            target: {}
+        };
 
-            return this.validateOptions(newOptions);
-        } else {
-            throw new gutil.PluginError(PLUGIN_NAME, 'Cannot find environment \'' + options.env + '\' in \' ~/.viewportrc.');
-        }
+        Object.assign(newOptions, this.options, options);
+
+        return this.validateOptions(newOptions);
     }
 
     validateOptions(options) {
         if (options.env && VIEWPORTRC.hasOwnProperty(options.env)) {
             options.target = Object.assign({}, options.target, VIEWPORTRC[options.env])
+        } else {
+            throw new gutil.PluginError(PLUGIN_NAME, 'Cannot find environment \'' + options.env + '\' in \' ~/.viewportrc.');
         }
+
         if (!options.targetPath) {
             options.targetPath = './'
         }


### PR DESCRIPTION
Add 'X-Atlassian-Token': 'no-check' header to uploadTheme POST request.

This should be merged before the changes in the Java App. The presented changes shouldn't lead to errors since the App will ignore the added header, since it has a XsrfProtectionExcluded annotation set on the regarding REST endpoint.

**Changes:**
- Removed the validation of the options object from `extendOptions`, since the object is validated in `validateOptions` before returning it.
- Added a deprecation notice as the module isn't used by new tools anymore. Every new product should now use the [viewport-uploader](https://github.com/K15t/viewport-uploader/) module.